### PR TITLE
win_draw_bytesの実装

### DIFF
--- a/src/kernel/define.h
+++ b/src/kernel/define.h
@@ -237,6 +237,7 @@ byte win_get_pixel(WINDOW* win, int x, int y);
 void win_draw_pixel(WINDOW* win, int x, int y, byte color);
 void win_draw_line(WINDOW* win, int x1, int y1, int x2, int y2, byte color);
 void win_draw_rect(WINDOW* win, int x, int y, int w, int h, byte color);
+void win_draw_bytes(WINDOW* win, int x, int y, int w, int h, byte* data);
 void win_draw_char(WINDOW* win, int x, int y, char c, byte color);
 void win_draw_text(WINDOW* win, int x, int y, byte* text, byte color);
 void bg_draw_pixel(int x, int y, byte color);

--- a/src/kernel/syscall.c
+++ b/src/kernel/syscall.c
@@ -55,6 +55,14 @@ void syscall(int sc_id, int param1, int param2, int param3, int param4, int para
             win_draw_text(win, x, y, text, color);
             break;
         }
+
+        case SYSCALL_ID_WIN_DRAW_BYTES: {
+            WINDOW *win = (WINDOW *) param1;
+            RECT *rect = (RECT *) param2;
+            byte *data = (byte *) param3;
+            win_draw_bytes(win, rect->x, rect->y, rect->w, rect->h, data);
+            break;
+        }
     }
 
     // 戻り値をスタックに入れる

--- a/src/kernel/window.c
+++ b/src/kernel/window.c
@@ -296,6 +296,15 @@ void win_draw_rect(WINDOW* win, int x, int y, int w, int h, byte color)
     }
 }
 
+void win_draw_bytes(WINDOW* win, int x, int y, int w, int h, byte* data)
+{
+    for (int i = 0; i < w; i++) {
+        for (int j = 0; j < h; j++) {
+            win_draw_pixel(win, i + x, j + y, data[w * j + i]);
+        }
+    }
+}
+
 void win_draw_char(WINDOW* win, int x, int y, char c, byte color)
 {
     int index = c * 16;

--- a/src/syscall/asm_syscall.s
+++ b/src/syscall/asm_syscall.s
@@ -173,3 +173,7 @@ _sc_win_draw_rect:
 .global _sc_win_draw_text
 _sc_win_draw_text:
     _asm_syscall_5 7
+
+.global _sc_win_draw_bytes
+_sc_win_draw_bytes:
+    _asm_syscall_3 8

--- a/src/syscall/define.h
+++ b/src/syscall/define.h
@@ -10,6 +10,7 @@
 #define SYSCALL_ID_WIN_CREATE           5
 #define SYSCALL_ID_WIN_DRAW_RECT        6
 #define SYSCALL_ID_WIN_DRAW_TEXT        7
+#define SYSCALL_ID_WIN_DRAW_BYTES       8
 
 // asm_syscall.s
 int _sc_example(int param1, int param2, int param3, int param4, int param5);
@@ -20,3 +21,4 @@ void _sc_sleep(int milliseconds);
 int _sc_win_create(RECT *rect);
 void _sc_win_draw_rect(int win_handle, RECT *rect, int color);
 void _sc_win_draw_text(int win_handle, int x, int y, char *text, int color);
+void _sc_win_draw_bytes(int win_handle, RECT *rect, byte *data);

--- a/src/tasks/example.c
+++ b/src/tasks/example.c
@@ -25,6 +25,26 @@ void main()
     _sc_win_draw_rect(win_handle, &rect, COL_DARKRED);
 
     rect.x = 18;
+    rect.y = 8;
+    rect.w = 64;
+    rect.h = 64;
+    byte data[64*64];
+    for (int i = 0; i < 64; i++) {
+        for (int j = 0; j < 64; j++) {
+            int x = i - 32;
+            int y = j - 32;
+            byte color;
+            if (x * x + y * y < 625) {
+                color = COL_DARKGREEN;
+            } else {
+                color = COL_NONE;
+            }
+            data[64 * j + i] = color;
+        }
+    }
+    _sc_win_draw_bytes(win_handle, &rect, data);
+
+    rect.x = 18;
     rect.y = 32;
     rect.w = 64;
     rect.h = 16;


### PR DESCRIPTION
バイト配列を描画するための win_draw_bytes 関数を実装し、システムコールでも呼び出せるようにした。